### PR TITLE
add make dep asciidoctor

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,4 +1,5 @@
 # Maintainer: Yurii Kolesnykov <root@yurikoles.com>
+# Contributor: Silvio Knizek <knizek@b1-systems.de>
 
 pkgname=zypper
 pkgver=1.14.26
@@ -8,7 +9,7 @@ arch=('i686' 'x86_64')
 url="https://github.com/openSUSE/zypper"
 license=('GPL')
 depends=('libzypp' 'libxml2' 'procps' 'readline' 'augeas')
-makedepends=('git' 'cmake' 'ninja' 'boost' 'asciidoc')
+makedepends=('git' 'cmake' 'ninja' 'boost' 'asciidoc' 'asciidoctor')
 provides=('zypper' 'apt')
 conflicts=('apt')
 source=("https://github.com/openSUSE/zypper/archive/${pkgver}.tar.gz"


### PR DESCRIPTION
current build fails with
```
CMake Error at doc/CMakeLists.txt:8 (MESSAGE):
  Could not find asciidoctor, please install the package
```
this make dep fixes it